### PR TITLE
Potential fix for code scanning alert no. 6: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/github/webhooks_controller.rb
+++ b/app/controllers/github/webhooks_controller.rb
@@ -1,9 +1,12 @@
 class Github::WebhooksController < ApplicationController
   include GithubWebhook::Processor
 
-  skip_before_action :verify_authenticity_token
-
   def github_push(payload)
+    unless valid_signature?(request)
+      head :unauthorized
+      return
+    end
+
     event = ::Github::PushEvent.new(payload)
 
     Lessons::UpdateContentJob.perform_later(event.modified_urls) if event.merged_to_main?
@@ -13,5 +16,13 @@ class Github::WebhooksController < ApplicationController
 
   def webhook_secret(_)
     ENV['GITHUB_WEBHOOK_SECRET']
+  end
+  def valid_signature?(request)
+    signature = 'sha256=' + OpenSSL::HMAC.hexdigest(
+      OpenSSL::Digest.new('sha256'),
+      webhook_secret(nil),
+      request.body.read
+    )
+    Rack::Utils.secure_compare(signature, request.headers['X-Hub-Signature-256'].to_s)
   end
 end


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/6](https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/6)

To fix the issue, we will:
1. Remove the `skip_before_action :verify_authenticity_token` line to re-enable CSRF protection.
2. Explicitly validate the webhook secret in the `github_push` action to ensure that only legitimate requests from GitHub are processed. This involves comparing the signature of the incoming request with the expected signature generated using the secret.
3. Use the `webhook_secret` method to retrieve the secret and validate the request signature.

This approach ensures that the application is protected against CSRF attacks while still allowing secure processing of GitHub webhook events.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
