### PR TITLE
Potential fix for code scanning alert no. 5: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -1,5 +1,4 @@
 class Api::PointsController < ApplicationController
-  skip_before_action :verify_authenticity_token
   before_action :authenticate
 
   def index


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/5](https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/5)

To address the issue, we will remove the `skip_before_action :verify_authenticity_token` line to re-enable CSRF protection for the controller. Additionally, we will ensure that the `protect_from_forgery` method is configured with `with: :exception` to raise an exception if an invalid CSRF token is provided. This approach ensures that the application is protected against CSRF attacks while maintaining secure behavior.

If the API is intended to be stateless and exclusively uses token-based authentication, we can explicitly document this and ensure that CSRF protection is not required. However, this would require a thorough review of the application's architecture and is outside the scope of this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
