### PR TITLE
Potential fix for code scanning alert no. 7: Stored cross-site scripting

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -8,7 +8,7 @@
     <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
       <article class="col-span-full xl:col-span-7 xl:col-start-2 xl:max-w-prose">
         <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
-          <%= @lesson.body.html_safe %>
+          <%= sanitize(@lesson.body) %>
 
           <% component.with_footer do %>
             <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/7](https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/7)

To fix the issue, we should ensure that the content of `@lesson.body` is sanitized before being rendered in the view. This can be achieved by using a library like `sanitize` to remove potentially dangerous HTML tags and attributes. The sanitized content can then be safely rendered without using `html_safe`.

The best approach is to sanitize `@lesson.body` in the view itself, ensuring that any potentially malicious content is removed before rendering. This avoids relying on assumptions about the data's safety at earlier stages (e.g., during storage).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
