### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ci-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   linters:
     name: Linters


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/4](https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Since the workflow primarily involves running linters and tests, it only requires read access to the repository contents. We will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
