### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/heroku-review-app-on-label.yml
+++ b/.github/workflows/heroku-review-app-on-label.yml
@@ -1,4 +1,7 @@
 name: Heroku Review App on label
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types: [labeled]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/1](https://github.com/Git-Hub-Chris/The-Odin-Project/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` to access repository contents if necessary.
- `pull-requests: write` to remove labels from pull requests.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
